### PR TITLE
[FEAT] 기존 이메일 재가입

### DIFF
--- a/src/main/java/org/example/tackit/domain/auth/login/controller/AuthController.java
+++ b/src/main/java/org/example/tackit/domain/auth/login/controller/AuthController.java
@@ -21,36 +21,21 @@ public class AuthController {
     private final AuthService authService;
     private final CheckService checkService;
 
+    // 회원가입
     @PostMapping("/sign-up")
     public ResponseEntity<?> signup(@RequestBody SignUpDto signUpDto) {
         authService.signup(signUpDto);
         return ResponseEntity.ok().body(Map.of("status", "OK", "message", "회원가입 성공했습니다."));
     }
 
+    // 로그인
     @PostMapping("/sign-in")
     public ResponseEntity<TokenDto> signIn(@RequestBody SignInDto signInDto) {
         TokenDto tokenDto = authService.signIn(signInDto);
         return ResponseEntity.ok(tokenDto);
     }
 
-    @GetMapping("/check-email")
-    public ResponseEntity<?> checkEmail(@RequestParam String email) {
-        boolean isDuplicated = checkService.isEmailDuplicated(email);
-        if (isDuplicated) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).body("이미 사용 중인 이메일입니다.");
-        }
-        return ResponseEntity.ok("사용 가능한 이메일입니다.");
-    }
-
-    @GetMapping("/check-nickname")
-    public ResponseEntity<?> checkNickname(@RequestParam String nickname) {
-        boolean isDuplicated = checkService.isNicknameDuplicated(nickname);
-        if (isDuplicated) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).body("이미 사용 중인 닉네임입니다.");
-        }
-        return ResponseEntity.ok("사용 가능한 닉네임입니다.");
-    }
-
+    // 토큰 재발급
     // 만료된 Access Token 대신 유효한 Refresh Token으로 새로운 Access Token을 발급
     @PostMapping("/reissue")
     public ResponseEntity<TokenDto> reissueToken(HttpServletRequest request) {

--- a/src/main/java/org/example/tackit/domain/auth/login/controller/CheckController.java
+++ b/src/main/java/org/example/tackit/domain/auth/login/controller/CheckController.java
@@ -1,0 +1,41 @@
+package org.example.tackit.domain.auth.login.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.tackit.domain.auth.login.repository.UserRepository;
+import org.example.tackit.domain.auth.login.service.CheckService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class CheckController {
+
+    private final UserRepository userRepository;
+    private final CheckService checkService;
+
+    // 기본 이메일 중복 확인
+    @GetMapping("/check-email")
+    public ResponseEntity<?> checkEmail(@RequestParam String email) {
+        boolean isDuplicated = checkService.isEmailDuplicated(email);
+        if (isDuplicated) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("이미 사용 중인 이메일입니다.");
+        }
+        return ResponseEntity.ok("사용 가능한 이메일입니다.");
+    }
+
+    // 기본 닉네임 중복 확인
+    @GetMapping("/check-nickname")
+    public ResponseEntity<?> checkNickname(@RequestParam String nickname) {
+        boolean isDuplicated = checkService.isNicknameDuplicated(nickname);
+        if (isDuplicated) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("이미 사용 중인 닉네임입니다.");
+        }
+        return ResponseEntity.ok("사용 가능한 닉네임입니다.");
+    }
+
+}

--- a/src/main/java/org/example/tackit/domain/auth/login/controller/RejoinCheckController.java
+++ b/src/main/java/org/example/tackit/domain/auth/login/controller/RejoinCheckController.java
@@ -1,0 +1,48 @@
+package org.example.tackit.domain.auth.login.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.tackit.domain.auth.login.repository.UserRepository;
+import org.example.tackit.domain.auth.login.service.CheckService;
+import org.example.tackit.domain.auth.login.service.RejoinCheckService;
+import org.example.tackit.domain.entity.Member;
+import org.example.tackit.domain.entity.Status;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class RejoinCheckController {
+
+    private final UserRepository userRepository;
+    private final RejoinCheckService rejoinCheckService;
+
+    // 이메일 중복 확인 + 탈퇴 이력 조회 
+    @GetMapping("/check-email-auth")
+    public ResponseEntity<String> checkEmailAuth(@RequestParam String email) {
+        String status = rejoinCheckService.checkEmailStatus(email);
+
+        if ("DELETED".equals(status)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("탈퇴 이력이 있는 이메일입니다.");
+        } else if ("ACTIVE".equals(status)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("이미 가입된 이메일입니다.");
+        } else {
+            return ResponseEntity.ok("사용 가능한 이메일입니다.");
+        }
+    }
+
+    // 탈퇴했던 회원 재가입
+    @DeleteMapping("/rejoin")
+    public ResponseEntity<String> rejoin(@RequestParam String email) {
+        boolean result = rejoinCheckService.deleteDeletedMember(email);
+        if (result) {
+            return ResponseEntity.ok("재가입을 위한 삭제 완료. 새로 회원가입 진행해주세요.");
+        } else {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("삭제할 탈퇴 이력의 이메일이 없습니다.");
+        }
+    }
+
+}

--- a/src/main/java/org/example/tackit/domain/auth/login/repository/UserRepository.java
+++ b/src/main/java/org/example/tackit/domain/auth/login/repository/UserRepository.java
@@ -1,15 +1,19 @@
 package org.example.tackit.domain.auth.login.repository;
 
 import org.example.tackit.domain.entity.Member;
+import org.example.tackit.domain.entity.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface UserRepository extends JpaRepository<Member, Integer> {
-    Optional<Member> findByEmail(String email); //그 유저 실제 정보 확인
-    boolean existsByEmail(String email); //있는지 없는지
+public interface UserRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email); //그 유저 실제 정보 추출
+    boolean existsByEmail(String email); // 이메일 존재 확인
     boolean existsByNickname(String nickname); //닉네임 중복 확인
+    boolean existsByEmailAndStatus(String email, Status status); // 이메일+상태 존재 확인
+    Optional<Member> findByEmailAndStatus(String email, Status status); // 이메일+상태 정보 추출
+    void deleteByEmail(String email); // 직접 삭제용
 }
 

--- a/src/main/java/org/example/tackit/domain/auth/login/service/RejoinCheckService.java
+++ b/src/main/java/org/example/tackit/domain/auth/login/service/RejoinCheckService.java
@@ -1,0 +1,37 @@
+package org.example.tackit.domain.auth.login.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.tackit.domain.auth.login.repository.UserRepository;
+import org.example.tackit.domain.entity.Member;
+import org.example.tackit.domain.entity.Status;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RejoinCheckService {
+    private final UserRepository userRepository;
+
+    // 회원 상태 조회
+    public String checkEmailStatus(String email) {
+        if (userRepository.existsByEmailAndStatus(email, Status.DELETED)) {
+            return "DELETED";
+        } else if (userRepository.existsByEmailAndStatus(email, Status.ACTIVE)) {
+            return "ACTIVE";
+        } else {
+            return "AVAILABLE";
+        }
+    }
+
+    // 탈퇴한 회원 삭제
+    public boolean deleteDeletedMember(String email) {
+        Optional<Member> deletedMember = userRepository.findByEmailAndStatus(email, Status.DELETED);
+        if (deletedMember.isPresent()) {
+            userRepository.delete(deletedMember.get());
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/org/example/tackit/domain/auth/logout/controller/LogoutController.java
+++ b/src/main/java/org/example/tackit/domain/auth/logout/controller/LogoutController.java
@@ -10,13 +10,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/Logout")
+@RequestMapping("/auth-logout")
 @RequiredArgsConstructor
 public class LogoutController {
 
     private final LogoutService logoutService;
 
-    @PostMapping("authLogout")
+    @PostMapping
     public ResponseEntity<String> logout(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {

--- a/src/main/java/org/example/tackit/domain/auth/logout/repository/LogoutRepository.java
+++ b/src/main/java/org/example/tackit/domain/auth/logout/repository/LogoutRepository.java
@@ -8,7 +8,4 @@ import java.util.Optional;
 
 public interface LogoutRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
-    boolean existsByEmail(String email);
-    boolean existsByEmailAndStatus(String email, Status status);
-    void deleteByEmail(String email); // 하드 삭제용
 }


### PR DESCRIPTION
### 이슈 번호
> #15 
### 작업 내용
* 이메일 중복 및 탈퇴 이력 확인 api 구현

```
200 OK: 사용 가능한 이메일입니다. (AVAILABLE)
409 conflict: 탈퇴 이력이 있는 이메일입니다. (DELETED)
409 conflict: 이미 가입된 이메일입니다. (ACTIVE) 
```

* 재가입 처리 (탈퇴한 계정 Hard delete)
```
200 OK: 재가입을 위한 삭제 완료. 새로 회원가입 진행해주세요.
404 Not found: 삭제할 탈퇴 이력의 이메일이 없습니다.
```
* 기본 이메일 중복 확인 MVC 파일 분리