### PR TITLE
[FEAT] 질문게시판 게시글 작성자와 관리자만 수정, 삭제

### DIFF
--- a/src/main/java/org/example/tackit/domain/QnA_post/controller/QnAPostController.java
+++ b/src/main/java/org/example/tackit/domain/QnA_post/controller/QnAPostController.java
@@ -12,6 +12,7 @@ import org.example.tackit.domain.free_post.dto.response.FreePostDTO;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -24,23 +25,26 @@ public class QnAPostController {
 
     // 게시글 생성
     @PostMapping("/create")
-    public ResponseEntity<QnAPostResponseDto> createQnAPost(@RequestBody QnAPostRequestDto dto, @AuthenticationPrincipal Member member) {
-        QnAPostResponseDto response = qnAPostService.createPost(dto, member);
+    public ResponseEntity<QnAPostResponseDto> createQnAPost(@RequestBody QnAPostRequestDto dto, @AuthenticationPrincipal UserDetails userDetails) {
+        String email = userDetails.getUsername(); // userDetails로부터 이메일 획득
+        QnAPostResponseDto response = qnAPostService.createPost(dto, email);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     // 게시글 수정
     @PutMapping("/{QnAPostId}")
-    public ResponseEntity<QnAPostResponseDto> updateQnAPost(@PathVariable("QnAPostId") long QnAPostId, @RequestBody UpdateQnARequestDto request, @AuthenticationPrincipal Member member){
-        QnAPostResponseDto updateResponse = qnAPostService.update(QnAPostId, request, member);
+    public ResponseEntity<QnAPostResponseDto> updateQnAPost(@PathVariable("QnAPostId") long QnAPostId, @RequestBody UpdateQnARequestDto request, @AuthenticationPrincipal UserDetails userDetails){
+        String email = userDetails.getUsername();
+        QnAPostResponseDto updateResponse = qnAPostService.update(QnAPostId, request, email);
 
         return ResponseEntity.ok().body(updateResponse);
     }
 
     // 게시글 삭제
     @DeleteMapping("/{QnAPostId}")
-    public ResponseEntity<QnAPostResponseDto> deleteQnAPost(@PathVariable("QnAPostId") long QnAPostId, @AuthenticationPrincipal Member member){
-        qnAPostService.delete(QnAPostId, member);
+    public ResponseEntity<QnAPostResponseDto> deleteQnAPost(@PathVariable("QnAPostId") long QnAPostId, @AuthenticationPrincipal UserDetails userDetails){
+        String email = userDetails.getUsername();
+        qnAPostService.delete(QnAPostId, email);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/org/example/tackit/domain/QnA_post/controller/QnAPostController.java
+++ b/src/main/java/org/example/tackit/domain/QnA_post/controller/QnAPostController.java
@@ -6,10 +6,12 @@ import org.example.tackit.domain.QnA_post.dto.request.UpdateQnARequestDto;
 import org.example.tackit.domain.QnA_post.dto.response.QnAPostResponseDto;
 import org.example.tackit.domain.QnA_post.repository.QnAPostRepository;
 import org.example.tackit.domain.QnA_post.service.QnAPostService;
+import org.example.tackit.domain.entity.Member;
 import org.example.tackit.domain.entity.QnAPost;
 import org.example.tackit.domain.free_post.dto.response.FreePostDTO;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,23 +24,23 @@ public class QnAPostController {
 
     // 게시글 생성
     @PostMapping("/create")
-    public ResponseEntity<QnAPostResponseDto> createQnAPost(@RequestBody QnAPostRequestDto dto) {
-        QnAPostResponseDto response = qnAPostService.createPost(dto);
+    public ResponseEntity<QnAPostResponseDto> createQnAPost(@RequestBody QnAPostRequestDto dto, @AuthenticationPrincipal Member member) {
+        QnAPostResponseDto response = qnAPostService.createPost(dto, member);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     // 게시글 수정
     @PutMapping("/{QnAPostId}")
-    public ResponseEntity<QnAPostResponseDto> updateQnAPost(@PathVariable("QnAPostId") long QnAPostId, @RequestBody UpdateQnARequestDto request){
-        QnAPostResponseDto updateResponse = qnAPostService.update(QnAPostId, request);
+    public ResponseEntity<QnAPostResponseDto> updateQnAPost(@PathVariable("QnAPostId") long QnAPostId, @RequestBody UpdateQnARequestDto request, @AuthenticationPrincipal Member member){
+        QnAPostResponseDto updateResponse = qnAPostService.update(QnAPostId, request, member);
 
         return ResponseEntity.ok().body(updateResponse);
     }
 
     // 게시글 삭제
     @DeleteMapping("/{QnAPostId}")
-    public ResponseEntity<QnAPostResponseDto> deleteQnAPost(@PathVariable("QnAPostId") long QnAPostId){
-        qnAPostService.delete(QnAPostId);
+    public ResponseEntity<QnAPostResponseDto> deleteQnAPost(@PathVariable("QnAPostId") long QnAPostId, @AuthenticationPrincipal Member member){
+        qnAPostService.delete(QnAPostId, member);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/org/example/tackit/domain/QnA_post/dto/request/QnAPostRequestDto.java
+++ b/src/main/java/org/example/tackit/domain/QnA_post/dto/request/QnAPostRequestDto.java
@@ -12,6 +12,5 @@ import java.time.LocalDateTime;
 public class QnAPostRequestDto {
     private String title;
     private String content;
-    private String nickname;
     private String tag;
 }

--- a/src/main/java/org/example/tackit/domain/QnA_post/repository/QnAMemberRepository.java
+++ b/src/main/java/org/example/tackit/domain/QnA_post/repository/QnAMemberRepository.java
@@ -8,6 +8,6 @@ import java.util.Optional;
 
 @Repository
 public interface QnAMemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByNickname(String nickname);
+    Optional<Member> findByEmail(String email);
 }
 

--- a/src/main/java/org/example/tackit/domain/QnA_post/service/QnAPostService.java
+++ b/src/main/java/org/example/tackit/domain/QnA_post/service/QnAPostService.java
@@ -25,11 +25,9 @@ public class QnAPostService {
     private final QnAPostRepository qnAPostRepository;
     private final QnAMemberRepository qnAMemberRepository;
 
-    // 게시글 작성
+    // 게시글 작성 (NEWBIE만 가능)
     @Transactional
-    public QnAPostResponseDto createPost(QnAPostRequestDto dto) {
-        Member member = qnAMemberRepository.findByNickname(dto.getNickname())
-                .orElseThrow(() -> new IllegalArgumentException("작성자가 존재하지 않습니다."));
+    public QnAPostResponseDto createPost(QnAPostRequestDto dto, Member member) {
 
         if (member.getRole() != Role.NEWBIE) {
             throw new AccessDeniedException("NEWBIE만 질문을 작성할 수 있습니다.");
@@ -50,31 +48,52 @@ public class QnAPostService {
         return new QnAPostResponseDto(post);
     }
 
-    // 게시글 수정
+    // 게시글 수정 (작성자, 관리자만 가능)
     @Transactional
-    public QnAPostResponseDto update(long id, UpdateQnARequestDto request){
+    public QnAPostResponseDto update(long id, UpdateQnARequestDto request, Member member){
         QnAPost post = qnAPostRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("작성자가 존재하지 않습니다."));
+
+        boolean isWriter = post.getWriter().getId().equals(member.getId());
+        boolean isAdmin = member.getRole() == Role.ADMIN;
+
+        if (!isWriter && !isAdmin) {
+            throw new AccessDeniedException("작성자 또는 관리자만 수정할 수 있습니다.");
+        }
 
         post.update(request.getTitle(), request.getContent(), request.getTag());
 
         return new QnAPostResponseDto(post);
     }
 
-    // 게시글 삭제
-    public void delete(long id){
-        qnAPostRepository.deleteById(id);
+    // 게시글 삭제 (작성자, 관리자만 가능)
+    @Transactional
+    public void delete(long id, Member member){
+        QnAPost post = qnAPostRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
+
+        boolean isWriter = post.getWriter().getId().equals(member.getId());
+        boolean isAdmin = member.getRole() == Role.ADMIN;
+
+        if (!isWriter && !isAdmin) {
+            throw new AccessDeniedException("작성자 또는 관리자만 삭제할 수 있습니다.");
+        }
+
+        qnAPostRepository.delete(post);
     }
 
     // 게시글 전체 조회
+    @Transactional(readOnly = true)
     public List<QnAPostResponseDto> findALl(){
         List<QnAPost> posts = qnAPostRepository.findAllByStatus(Status.ACTIVE);
-        return posts.stream()
+        return posts
+                .stream()
                 .map(QnAPostResponseDto::new)
                 .toList();
     }
 
     // 게시글 상세 조회
+    @Transactional(readOnly = true)
     public QnAPostResponseDto getPostById(Long id) {
         QnAPost QnAPost = qnAPostRepository.findById(id)
                 .orElseThrow( () -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));

--- a/src/main/java/org/example/tackit/domain/QnA_post/service/QnAPostService.java
+++ b/src/main/java/org/example/tackit/domain/QnA_post/service/QnAPostService.java
@@ -27,7 +27,9 @@ public class QnAPostService {
 
     // 게시글 작성 (NEWBIE만 가능)
     @Transactional
-    public QnAPostResponseDto createPost(QnAPostRequestDto dto, Member member) {
+    public QnAPostResponseDto createPost(QnAPostRequestDto dto, String email) {
+        Member member = qnAMemberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
         if (member.getRole() != Role.NEWBIE) {
             throw new AccessDeniedException("NEWBIE만 질문을 작성할 수 있습니다.");
@@ -50,9 +52,12 @@ public class QnAPostService {
 
     // 게시글 수정 (작성자, 관리자만 가능)
     @Transactional
-    public QnAPostResponseDto update(long id, UpdateQnARequestDto request, Member member){
+    public QnAPostResponseDto update(long id, UpdateQnARequestDto request, String email){
+        Member member = qnAMemberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
         QnAPost post = qnAPostRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("작성자가 존재하지 않습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
 
         boolean isWriter = post.getWriter().getId().equals(member.getId());
         boolean isAdmin = member.getRole() == Role.ADMIN;
@@ -68,7 +73,10 @@ public class QnAPostService {
 
     // 게시글 삭제 (작성자, 관리자만 가능)
     @Transactional
-    public void delete(long id, Member member){
+    public void delete(long id, String email){
+        Member member = qnAMemberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
         QnAPost post = qnAPostRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
 

--- a/src/main/java/org/example/tackit/domain/entity/Member.java
+++ b/src/main/java/org/example/tackit/domain/entity/Member.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int id;
+    private Long id;
 
     @Column(nullable = false, unique = true)
     private String email;


### PR DESCRIPTION
### 이슈 번호
> #21 

### 작업 내용
* 게시글 수정 - 작성자, 관리자만 가능
* 게시글 삭제 - 작성자, 관리자만 가능
* 게시글 조회 readOnly 설정
* Userdetail에서 email 정보를 가져와서 repository에서 정보 조회하도록 구현