### PR TITLE
[FEAT] 질문게시판 찜하기/취소

### DIFF
--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/controller/QnAPostScrapController.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/controller/QnAPostScrapController.java
@@ -1,0 +1,27 @@
+package org.example.tackit.domain.QnA_board.QnA_post.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.tackit.domain.QnA_board.QnA_post.dto.response.QnAScrapResponseDto;
+import org.example.tackit.domain.QnA_board.QnA_post.service.QnAScrapService;
+import org.example.tackit.domain.auth.login.security.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/qna_post")
+public class QnAPostScrapController {
+    private final QnAScrapService qnAScrapService;
+
+    @PostMapping("/{postId}/scrap")
+    public ResponseEntity<QnAScrapResponseDto> toggleScrap(@PathVariable long postId, @AuthenticationPrincipal CustomUserDetails userDetails){
+        String org = userDetails.getOrganization();
+        String email = userDetails.getUsername();
+        QnAScrapResponseDto response = qnAScrapService.toggleScrap(postId, email, org);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/dto/response/QnAScrapResponseDto.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/dto/response/QnAScrapResponseDto.java
@@ -1,0 +1,16 @@
+package org.example.tackit.domain.QnA_board.QnA_post.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class QnAScrapResponseDto {
+    private boolean scrapped;       // 현재 찜 상태
+    private LocalDateTime savedAt;  // 찜한 시각 (찜일 경우만 값 있음)
+
+}

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/repository/QnAScrapRepository.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/repository/QnAScrapRepository.java
@@ -1,0 +1,15 @@
+package org.example.tackit.domain.QnA_board.QnA_post.repository;
+
+import org.example.tackit.domain.entity.Member;
+import org.example.tackit.domain.entity.QnAPost;
+import org.example.tackit.domain.entity.QnAScrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface QnAScrapRepository extends JpaRepository<QnAScrap, Long> {
+    Optional<QnAScrap> findByUserAndQnaPost(Member user, QnAPost qnaPost);
+    void deleteByUserAndQnaPost(Member user, QnAPost qnaPost);
+}

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/service/QnAPostService.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/service/QnAPostService.java
@@ -103,8 +103,8 @@ public class QnAPostService {
         if (!isWriter && !isAdmin) {
             throw new AccessDeniedException("작성자 또는 관리자만 삭제할 수 있습니다.");
         }
-        tagService.deleteTagsByPost(post);
-        qnAPostRepository.delete(post);
+       // tagService.deleteTagsByPost(post);
+        post.markAsDeleted(); //Deleted로 soft delete
     }
 
     // 게시글 전체 조회

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/service/QnAScrapService.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/service/QnAScrapService.java
@@ -1,0 +1,54 @@
+package org.example.tackit.domain.QnA_board.QnA_post.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.tackit.domain.QnA_board.QnA_post.dto.response.QnAScrapResponseDto;
+import org.example.tackit.domain.QnA_board.QnA_post.repository.QnAMemberRepository;
+import org.example.tackit.domain.QnA_board.QnA_post.repository.QnAPostRepository;
+import org.example.tackit.domain.QnA_board.QnA_post.repository.QnAScrapRepository;
+import org.example.tackit.domain.entity.Member;
+import org.example.tackit.domain.entity.QnAPost;
+import org.example.tackit.domain.entity.QnAScrap;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class QnAScrapService {
+    private final QnAScrapRepository qnAScrapRepository;
+    private final QnAPostRepository qnAPostRepository;
+    private final QnAMemberRepository qnAMemberRepository;
+
+    @Transactional
+    public QnAScrapResponseDto toggleScrap(long postId, String email, String userOrg){
+        Member user = qnAMemberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        QnAPost post = qnAPostRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
+
+        // 작성글의 소속과 찜하는 사람 간 소속(organization)이 일치하지 않으면 예외
+        if (!post.getWriter().getOrganization().equals(userOrg)) {
+            throw new AccessDeniedException("해당 조직 게시글이 아닙니다.");
+        }
+
+        Optional<QnAScrap> existing = qnAScrapRepository.findByUserAndQnaPost(user, post);
+
+        if (existing.isPresent()) {
+            qnAScrapRepository.delete(existing.get());
+            return new QnAScrapResponseDto(false, null);
+        } else {
+            QnAScrap scrap = QnAScrap.builder()
+                    .user(user)
+                    .qnaPost(post)
+                    .savedAt(LocalDateTime.now())
+                    .build();
+            qnAScrapRepository.save(scrap);
+            return new QnAScrapResponseDto(true, scrap.getSavedAt());
+        }
+    }
+
+}

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_scrap/controller/QnAScrapController.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_scrap/controller/QnAScrapController.java
@@ -1,0 +1,11 @@
+package org.example.tackit.domain.QnA_board.QnA_scrap.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/qna_posts")
+public class QnAScrapController {
+}

--- a/src/main/java/org/example/tackit/domain/entity/QnAPost.java
+++ b/src/main/java/org/example/tackit/domain/entity/QnAPost.java
@@ -38,4 +38,9 @@ public class QnAPost {
         this.content = content;
     }
 
+    public void markAsDeleted() {
+        this.status = Status.DELETED;
+    }
+
+
 }

--- a/src/main/java/org/example/tackit/domain/entity/QnAScrap.java
+++ b/src/main/java/org/example/tackit/domain/entity/QnAScrap.java
@@ -1,6 +1,7 @@
 package org.example.tackit.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,15 +16,26 @@ public class QnAScrap {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
-    private Member userId;
+    private Member user;
 
-    @ManyToOne
-    @JoinColumn(name = "qna_id", nullable = false)
-    private FreePost qnaId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "qna_post_id", nullable = false)
+    private QnAPost qnaPost;
 
-    private LocalDateTime saved_at;
+    @Column(nullable = false)
+    private LocalDateTime savedAt;
 
-    private Post type = Post.QnA;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Post type;
+
+    @Builder
+    public QnAScrap(Member user, QnAPost qnaPost, LocalDateTime savedAt) {
+        this.user = user;
+        this.qnaPost = qnaPost;
+        this.savedAt = savedAt;
+        this.type = Post.QnA; // 여기서 기본값 명확하게 지정
+    }
 }

--- a/src/main/java/org/example/tackit/domain/entity/QnATag.java
+++ b/src/main/java/org/example/tackit/domain/entity/QnATag.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Table(name="qna_tag", uniqueConstraints = @UniqueConstraint(columnNames = "tagName") )
+@Table(name="qna_tag", uniqueConstraints = @UniqueConstraint(name = "uq_tag_tagname", columnNames = "tagName") )
 public class QnATag {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
### 이슈 번호
> #23

### 작업 내용
* 질문게시판 게시글 찜하기/취소 api
   *  작성글의 소속과 찜하는 사람 간 소속(organization)이 일치하지 않으면 예외
* 해시태그 유니크 constraint name 지정
* 게시글 hard delete 삭제 -> soft delete로 수정
