### PR TITLE
[FEAT, REFACTOR] 질문 페이징, n+1 처리

### DIFF
--- a/src/main/java/org/example/tackit/config/SecurityConfig.java
+++ b/src/main/java/org/example/tackit/config/SecurityConfig.java
@@ -68,7 +68,7 @@ public class SecurityConfig {
                 )
 
                 .authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
-                        .requestMatchers("/admin/**").hasAuthority("ADMIN") // 관리자 페이지 role 추가
+                        .requestMatchers("/api/admin/**").hasAuthority("ADMIN") // 관리자 페이지 role 추가
                         .requestMatchers("/auth/**") // 로그인, 회원가입은 열어주기
                         .permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_comment/controller/QnACommentController.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_comment/controller/QnACommentController.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/qna_comment")
+@RequestMapping("/api/qna-comment")
 public class QnACommentController {
 
     private final QnACommentService qnACommentService;

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_comment/repository/QnACommentRepository.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_comment/repository/QnACommentRepository.java
@@ -3,6 +3,8 @@ package org.example.tackit.domain.QnA_board.QnA_comment.repository;
 import org.example.tackit.domain.entity.Member;
 import org.example.tackit.domain.entity.QnAComment;
 import org.example.tackit.domain.entity.QnAPost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,6 +13,6 @@ import java.util.List;
 @Repository
 public interface QnACommentRepository extends JpaRepository<QnAComment, Long> {
     List<QnAComment> findByQnAPost(QnAPost post);
-    List<QnAComment> findByWriter(Member member);
+    Page<QnAComment> findByWriter(Member writer, Pageable pageable);
 }
 

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/controller/QnAPostController.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/controller/QnAPostController.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/qna_post")
+@RequestMapping("/api/qna-post")
 public class QnAPostController {
     private final QnAPostService qnAPostService;
 

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/controller/QnAPostController.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/controller/QnAPostController.java
@@ -6,6 +6,10 @@ import org.example.tackit.domain.QnA_board.QnA_post.dto.request.UpdateQnARequest
 import org.example.tackit.domain.QnA_board.QnA_post.dto.response.QnAPostResponseDto;
 import org.example.tackit.domain.QnA_board.QnA_post.service.QnAPostService;
 import org.example.tackit.domain.auth.login.security.CustomUserDetails;
+import org.example.tackit.global.dto.PageResponseDTO;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -51,11 +55,15 @@ public class QnAPostController {
 
     // 게시글 전체 조회
     @GetMapping("/list")
-    public ResponseEntity<List<QnAPostResponseDto>> findALlQnAPost(@AuthenticationPrincipal CustomUserDetails userDetails){
+    public ResponseEntity<PageResponseDTO<QnAPostResponseDto>> findAllQnAPost(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC, size = 5) Pageable pageable
+    ) {
         String org = userDetails.getOrganization();
-        List<QnAPostResponseDto> posts = qnAPostService.findALl(org);
-        return ResponseEntity.ok().body(posts);
+        PageResponseDTO<QnAPostResponseDto> page = qnAPostService.findAll(org, pageable);
+        return ResponseEntity.ok(page);
     }
+
 
     // 게시글 상세 조회
     @GetMapping("/{QnAPostId}")

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/controller/QnAPostScrapController.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/controller/QnAPostScrapController.java
@@ -6,6 +6,10 @@ import org.example.tackit.domain.QnA_board.QnA_post.dto.response.QnACheckScrapRe
 import org.example.tackit.domain.QnA_board.QnA_post.dto.response.QnAScrapResponseDto;
 import org.example.tackit.domain.QnA_board.QnA_post.service.QnAScrapService;
 import org.example.tackit.domain.auth.login.security.CustomUserDetails;
+import org.example.tackit.global.dto.PageResponseDTO;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -18,6 +22,7 @@ import java.util.List;
 public class QnAPostScrapController {
     private final QnAScrapService qnAScrapService;
 
+    // 찜하기
     @PostMapping("/{postId}/scrap")
     public ResponseEntity<QnAScrapResponseDto> toggleScrap(@PathVariable long postId, @AuthenticationPrincipal CustomUserDetails userDetails){
         String org = userDetails.getOrganization();
@@ -26,11 +31,13 @@ public class QnAPostScrapController {
         return ResponseEntity.ok(response);
     }
 
+    // 찜한 글 보기
     @GetMapping("/scrap")
-    public ResponseEntity<List<QnACheckScrapResponseDto>> getMyScrapList(@AuthenticationPrincipal CustomUserDetails userDetails){
-        String email = userDetails.getUsername();
-        List<QnACheckScrapResponseDto> scraps = qnAScrapService.getMyQnAScraps(email);
-        return ResponseEntity.ok(scraps);
+    public ResponseEntity<PageResponseDTO<QnACheckScrapResponseDto>> getMyScraps(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(qnAScrapService.getMyQnAScraps(userDetails.getEmail(), pageable));
     }
 
 }

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/controller/QnAPostScrapController.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/controller/QnAPostScrapController.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/qna_post")
+@RequestMapping("/api/qna-post")
 public class QnAPostScrapController {
     private final QnAScrapService qnAScrapService;
 

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/dto/response/QnACheckScrapResponseDto.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/dto/response/QnACheckScrapResponseDto.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.example.tackit.domain.entity.Post;
+import org.example.tackit.domain.entity.QnAPost;
 
 import java.time.LocalDateTime;
 
@@ -17,4 +18,15 @@ public class QnACheckScrapResponseDto {
     private String writer;
     private LocalDateTime createdAt;
     private Post type;
+
+    public static QnACheckScrapResponseDto fromEntity(QnAPost post, Post type) {
+        return QnACheckScrapResponseDto.builder()
+                .postId(post.getId())
+                .title(post.getTitle())
+                .writer(post.getWriter().getNickname())
+                .createdAt(post.getCreatedAt())
+                .type(type)
+                .build();
+    }
+
 }

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/repository/QnAPostRepository.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/repository/QnAPostRepository.java
@@ -4,6 +4,8 @@ import org.example.tackit.domain.entity.Member;
 import org.example.tackit.domain.entity.Post;
 import org.example.tackit.domain.entity.QnAPost;
 import org.example.tackit.domain.entity.Status;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,6 +16,6 @@ public interface QnAPostRepository extends JpaRepository<QnAPost, Long> {
     // 선택적으로 질문 게시글만 조회할 때 사용
     List<QnAPost> findByType(Post type);
     // 상태로 조회
-    List<QnAPost> findAllByStatusAndWriter_Organization(Status status, String organization);
+    Page<QnAPost> findAllByStatusAndWriter_Organization(Status status, String org, Pageable pageable);
     List<QnAPost> findByWriter(Member member);
 }

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/repository/QnAPostRepository.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/repository/QnAPostRepository.java
@@ -17,5 +17,5 @@ public interface QnAPostRepository extends JpaRepository<QnAPost, Long> {
     List<QnAPost> findByType(Post type);
     // 상태로 조회
     Page<QnAPost> findAllByStatusAndWriter_Organization(Status status, String org, Pageable pageable);
-    List<QnAPost> findByWriter(Member member);
+    Page<QnAPost> findByWriterAndStatus(Member writer, Status status, Pageable pageable);
 }

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/repository/QnAScrapRepository.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/repository/QnAScrapRepository.java
@@ -4,6 +4,9 @@ import org.example.tackit.domain.entity.Member;
 import org.example.tackit.domain.entity.Post;
 import org.example.tackit.domain.entity.QnAPost;
 import org.example.tackit.domain.entity.QnAScrap;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,5 +17,6 @@ import java.util.Optional;
 public interface QnAScrapRepository extends JpaRepository<QnAScrap, Long> {
     Optional<QnAScrap> findByUserAndQnaPost(Member user, QnAPost qnaPost);
     void deleteByUserAndQnaPost(Member user, QnAPost qnaPost);
-    List<QnAScrap> findByUserAndType(Member user, Post type);
+    @EntityGraph(attributePaths = {"qnaPost", "qnaPost.writer"}) // 페이징 함께 지원, writer까지 fetch해서 n+1방지
+    Page<QnAScrap> findByUserAndType(Member user, Post type, Pageable pageable);
 }

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/service/QnAPostService.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/service/QnAPostService.java
@@ -7,6 +7,9 @@ import org.example.tackit.domain.QnA_board.QnA_post.dto.response.QnAPostResponse
 import org.example.tackit.domain.QnA_board.QnA_post.repository.QnAMemberRepository;
 import org.example.tackit.domain.QnA_board.QnA_post.repository.QnAPostRepository;
 import org.example.tackit.domain.entity.*;
+import org.example.tackit.global.dto.PageResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -107,25 +110,22 @@ public class QnAPostService {
     }
 
     // 게시글 전체 조회
-    @Transactional(readOnly = true)
-    public List<QnAPostResponseDto> findALl(String org){
-        List<QnAPost> posts = qnAPostRepository.findAllByStatusAndWriter_Organization(Status.ACTIVE, org);
-        return posts
-                .stream()
-                .map(post -> {
-                    List<String> tagNames = tagService.getTagNamesByPost(post);
+    public PageResponseDTO<QnAPostResponseDto> findAll(String org, Pageable pageable) {
+        Page<QnAPost> page = qnAPostRepository.findAllByStatusAndWriter_Organization(Status.ACTIVE, org, pageable);
 
-                    return QnAPostResponseDto.builder()
-                            .postId(post.getId())
-                            .writer(post.getWriter().getNickname())
-                            .title(post.getTitle())
-                            .content(post.getContent())
-                            .createdAt(post.getCreatedAt())
-                            .tags(tagNames)
-                            .build();
-                })
-                .toList();
+        return PageResponseDTO.from(page, post -> {
+            List<String> tagNames = tagService.getTagNamesByPost(post);
+            return QnAPostResponseDto.builder()
+                    .postId(post.getId())
+                    .writer(post.getWriter().getNickname())
+                    .title(post.getTitle())
+                    .content(post.getContent())
+                    .createdAt(post.getCreatedAt())
+                    .tags(tagNames)
+                    .build();
+        });
     }
+
 
     // 게시글 상세 조회
     @Transactional(readOnly = true)

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/controller/QnATagController.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/controller/QnATagController.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/qna_tags")
+@RequestMapping("/api/qna-tags")
 public class QnATagController {
     private final QnATagService qnATagService;
 

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/repository/QnAPostTagMapRepository.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/repository/QnAPostTagMapRepository.java
@@ -16,4 +16,6 @@ public interface QnAPostTagMapRepository extends JpaRepository<QnATagMap, Long> 
     List<QnATagMap> findByQnaPost(QnAPost qnaPost);
     // 특정 태그에 연결된 게시글 조회
     List<QnATagMap> findByTag(QnATag tag);
+    List<QnATagMap> findByQnaPostIn(List<QnAPost> posts);
+
 }

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/repository/QnATagRepository.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/repository/QnATagRepository.java
@@ -11,6 +11,4 @@ import java.util.Optional;
 
 @Repository
 public interface QnATagRepository extends JpaRepository<QnATag, Long> {
-    // 태그 이름으로 중복 검사
-    Optional<QnATag> findByTagName(String tagName);
 }

--- a/src/main/java/org/example/tackit/domain/mypage/controller/MemberController.java
+++ b/src/main/java/org/example/tackit/domain/mypage/controller/MemberController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/members")
+@RequestMapping("/api/members")
 public class MemberController {
 
     private final MemberService memberService;

--- a/src/main/java/org/example/tackit/domain/mypage/controller/MypageQnAController.java
+++ b/src/main/java/org/example/tackit/domain/mypage/controller/MypageQnAController.java
@@ -6,6 +6,10 @@ import org.example.tackit.domain.auth.login.security.CustomUserDetails;
 import org.example.tackit.domain.mypage.dto.response.QnAMyCommentResponseDto;
 import org.example.tackit.domain.mypage.dto.response.QnAMyPostResponseDto;
 import org.example.tackit.domain.mypage.service.MyPageQnAService;
+import org.example.tackit.global.dto.PageResponseDTO;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,14 +27,24 @@ public class MypageQnAController {
 
     // 질문게시판) 내가 쓴 게시글 조회
     @GetMapping("/qna_posts")
-    public ResponseEntity<List<QnAMyPostResponseDto>> getMyQnaPosts(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        return ResponseEntity.ok(myPageQnAService.getMyPosts(userDetails.getUsername()));
+    public ResponseEntity<PageResponseDTO<QnAMyPostResponseDto>> getMyQnaPosts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC, size = 5) Pageable pageable
+    ) {
+        return ResponseEntity.ok(
+                myPageQnAService.getMyPosts(userDetails.getUsername(), pageable)
+        );
     }
 
     // 질문게시판) 내가 쓴 댓글 조회
     @GetMapping("/qna_comments")
-    public ResponseEntity<List<QnAMyCommentResponseDto>> getMyQnaComments(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        return ResponseEntity.ok(myPageQnAService.getMyComments(userDetails.getUsername()));
+    public ResponseEntity<PageResponseDTO<QnAMyCommentResponseDto>> getMyQnaComments(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC, size = 5) Pageable pageable
+    ) {
+        return ResponseEntity.ok(
+                myPageQnAService.getMyComments(userDetails.getUsername(), pageable)
+        );
     }
 
 }

--- a/src/main/java/org/example/tackit/domain/mypage/controller/MypageQnAController.java
+++ b/src/main/java/org/example/tackit/domain/mypage/controller/MypageQnAController.java
@@ -20,13 +20,13 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/mypage")
+@RequestMapping("/api/mypage")
 public class MypageQnAController {
 
     private final MyPageQnAService myPageQnAService;
 
     // 질문게시판) 내가 쓴 게시글 조회
-    @GetMapping("/qna_posts")
+    @GetMapping("/qna-posts")
     public ResponseEntity<PageResponseDTO<QnAMyPostResponseDto>> getMyQnaPosts(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC, size = 5) Pageable pageable
@@ -37,7 +37,7 @@ public class MypageQnAController {
     }
 
     // 질문게시판) 내가 쓴 댓글 조회
-    @GetMapping("/qna_comments")
+    @GetMapping("/qna-comments")
     public ResponseEntity<PageResponseDTO<QnAMyCommentResponseDto>> getMyQnaComments(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC, size = 5) Pageable pageable

--- a/src/main/java/org/example/tackit/domain/mypage/dto/response/QnAMyCommentResponseDto.java
+++ b/src/main/java/org/example/tackit/domain/mypage/dto/response/QnAMyCommentResponseDto.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.tackit.domain.entity.Post;
+import org.example.tackit.domain.entity.QnAComment;
 
 import java.time.LocalDateTime;
 
@@ -18,4 +19,15 @@ public class QnAMyCommentResponseDto {
     private String content;
     private LocalDateTime createdAt;
     private Post type;
+
+    public static QnAMyCommentResponseDto fromEntity(QnAComment comment) {
+        return QnAMyCommentResponseDto.builder()
+                .commentId(comment.getId())
+                .postId(comment.getQnAPost().getId())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .type(comment.getQnAPost().getType())
+                .build();
+    }
+
 }

--- a/src/main/java/org/example/tackit/domain/mypage/dto/response/QnAMyPostResponseDto.java
+++ b/src/main/java/org/example/tackit/domain/mypage/dto/response/QnAMyPostResponseDto.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.tackit.domain.entity.Post;
+import org.example.tackit.domain.entity.QnAPost;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -20,4 +21,15 @@ public class QnAMyPostResponseDto {
     private LocalDateTime createdAt;
     private List<String> tags;
     private Post type;
+
+    public static QnAMyPostResponseDto fromEntity(QnAPost post, List<String> tags) {
+        return QnAMyPostResponseDto.builder()
+                .postId(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .createdAt(post.getCreatedAt())
+                .tags(tags)
+                .type(post.getType())
+                .build();
+    }
 }

--- a/src/main/java/org/example/tackit/domain/mypage/service/MyPageQnAService.java
+++ b/src/main/java/org/example/tackit/domain/mypage/service/MyPageQnAService.java
@@ -6,13 +6,20 @@ import org.example.tackit.domain.QnA_board.QnA_post.repository.QnAMemberReposito
 import org.example.tackit.domain.QnA_board.QnA_post.repository.QnAPostRepository;
 import org.example.tackit.domain.QnA_board.QnA_tag.repository.QnAPostTagMapRepository;
 import org.example.tackit.domain.entity.Member;
+import org.example.tackit.domain.entity.QnAComment;
+import org.example.tackit.domain.entity.QnAPost;
 import org.example.tackit.domain.entity.Status;
 import org.example.tackit.domain.mypage.dto.response.QnAMyCommentResponseDto;
 import org.example.tackit.domain.mypage.dto.response.QnAMyPostResponseDto;
+import org.example.tackit.global.dto.PageResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,44 +31,37 @@ public class MyPageQnAService {
 
     // 질문게시판) 내가 쓴 게시글 조회
     @Transactional(readOnly = true)
-    public List<QnAMyPostResponseDto> getMyPosts(String email) {
+    public PageResponseDTO<QnAMyPostResponseDto> getMyPosts(String email, Pageable pageable) {
         Member member = qnAMemberRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
-        return qnAPostRepository.findByWriter(member).stream()
-                .filter(post -> post.getStatus() == Status.ACTIVE)
-                .map(post -> {
-                    List<String> tags = qnAPostTagMapRepository.findByQnaPost(post).stream()
-                            .map(mapping -> mapping.getTag().getTagName())
-                            .toList();
-                    return QnAMyPostResponseDto.builder()
-                            .postId(post.getId())
-                            .title(post.getTitle())
-                            .content(post.getContent())
-                            .createdAt(post.getCreatedAt())
-                            .tags(tags)
-                            .type(post.getType())
-                            .build();
-                }).toList();
+        Page<QnAPost> postPage = qnAPostRepository.findByWriterAndStatus(member, Status.ACTIVE, pageable);
+        List<QnAPost> posts = postPage.getContent();
+
+        // 태그 일괄 조회 (N+1 방지)
+        Map<Long, List<String>> tagMap = qnAPostTagMapRepository.findByQnaPostIn(posts).stream()
+                .collect(Collectors.groupingBy(
+                        mapping -> mapping.getQnaPost().getId(),
+                        Collectors.mapping(mapping -> mapping.getTag().getTagName(), Collectors.toList())
+                ));
+
+        return PageResponseDTO.from(postPage, post ->
+                QnAMyPostResponseDto.fromEntity(post, tagMap.getOrDefault(post.getId(), List.of()))
+        );
     }
 
 
     // 질문게시판) 내가 쓴 댓글 조회
     @Transactional(readOnly = true)
-    public List<QnAMyCommentResponseDto> getMyComments(String email) {
+    public PageResponseDTO<QnAMyCommentResponseDto> getMyComments(String email, Pageable pageable) {
         Member member = qnAMemberRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
-        return qnACommentRepository.findByWriter(member).stream()
-                .map(comment -> QnAMyCommentResponseDto.builder()
-                        .commentId(comment.getId())
-                        .postId(comment.getQnAPost().getId())
-                        .content(comment.getContent())
-                        .createdAt(comment.getCreatedAt())
-                        .type(comment.getQnAPost().getType())
-                        .build())
-                .toList();
+        Page<QnAComment> commentPage = qnACommentRepository.findByWriter(member, pageable);
+
+        return PageResponseDTO.from(commentPage, QnAMyCommentResponseDto::fromEntity);
     }
+
 
 
 }


### PR DESCRIPTION
### 이슈 번호
> #49 
#50

### 작업 내용
* 게시글 전체 조회 페이징
* 내가 찜한 글 보기 페이징
    * n+1 방지: entitygraph 처리 - 개인의 단일 필드 조회이기 때문
* 내가 작성한 글 확인 페이징
    * n+1 방지: map 후처리 
* 내가 작성한 댓글 확인 페이징
* controller RESTFul 하게 정리 
    * /api/** 통일
    * 하이픈(-) 사용으로 통일


### 기타
* 찜한 글 보기 ) entitygraph 처리 - 개인의 단일 필드 조회이기 때문 (1:1)
* 작성 글 보기 ) map 후처리 - 복합 필드 조합이 필요하기 때문 (1:N)

* 위처럼 생각해서 n+1 관계 리팩토링 했는데, 로직상 괜찮은지 확인 부탁드립니다
* tip 게시판이 fromEntity 형식이라 전체적으로 맞춰서 리팩토링 진행했습니다! 