### PR TITLE
[FEAT, REFACTOR] 질문 스크랩 태그 응답, 태그 필터링 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,12 @@ dependencies {
 
     //openapitools 설치 - jsonNullable
     implementation 'org.openapitools:jackson-databind-nullable:0.2.4'
+
+    // querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/tackit/config/QueryDSLConfig.java
+++ b/src/main/java/org/example/tackit/config/QueryDSLConfig.java
@@ -1,0 +1,18 @@
+package org.example.tackit.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/org/example/tackit/config/Redis/RedisProperties.java
+++ b/src/main/java/org/example/tackit/config/Redis/RedisProperties.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Getter
-@PropertySource("application.properties")
+@PropertySource("classpath:application.properties")
 public class RedisProperties {
     @Value("${spring.data.redis.port}")
     private int port;

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/controller/QnAPostScrapController.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/controller/QnAPostScrapController.java
@@ -35,7 +35,7 @@ public class QnAPostScrapController {
     @GetMapping("/scrap")
     public ResponseEntity<PageResponseDTO<QnACheckScrapResponseDto>> getMyScraps(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(size = 5, sort = "savedAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return ResponseEntity.ok(qnAScrapService.getMyQnAScraps(userDetails.getEmail(), pageable));
     }

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/dto/response/QnACheckScrapResponseDto.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/dto/response/QnACheckScrapResponseDto.java
@@ -8,22 +8,32 @@ import org.example.tackit.domain.entity.Post;
 import org.example.tackit.domain.entity.QnAPost;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
 @Builder
 public class QnACheckScrapResponseDto {
-    private Long postId;
-    private String title;
-    private String writer;
-    private LocalDateTime createdAt;
-    private Post type;
+    private final Long postId;
+    private final String title;
+    private final String writer;
+    private final String contentPreview;
+    private final List<String> tags;
+    private final LocalDateTime createdAt;
+    private final Post type;
 
-    public static QnACheckScrapResponseDto fromEntity(QnAPost post, Post type) {
+    public static QnACheckScrapResponseDto fromEntity(QnAPost post, Post type, List<String> tagNames) {
+        String content = post.getContent();
+        if (content.length() > 100) {
+            content = content.substring(0, 100) + "...";
+        }
+
         return QnACheckScrapResponseDto.builder()
                 .postId(post.getId())
                 .title(post.getTitle())
                 .writer(post.getWriter().getNickname())
+                .contentPreview(content)
+                .tags(tagNames)
                 .createdAt(post.getCreatedAt())
                 .type(type)
                 .build();

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/dto/response/QnAPostResponseDto.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/dto/response/QnAPostResponseDto.java
@@ -20,12 +20,14 @@ public class QnAPostResponseDto {
     private final List<String> tags;
     private final LocalDateTime createdAt;
 
-    public QnAPostResponseDto(QnAPost post, List<String> tags) {
-        this.postId = post.getId();
-        this.writer = post.getWriter().getNickname();
-        this.title = post.getTitle();
-        this.content = post.getContent();
-        this.tags = tags;
-        this.createdAt = post.getCreatedAt();
+    public static QnAPostResponseDto fromEntity(QnAPost post, List<String> tagNames) {
+        return QnAPostResponseDto.builder()
+                .postId(post.getId())
+                .writer(post.getWriter().getNickname())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .tags(tagNames)
+                .createdAt(post.getCreatedAt())
+                .build();
     }
 }

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/repository/QnAScrapRepository.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/repository/QnAScrapRepository.java
@@ -1,9 +1,6 @@
 package org.example.tackit.domain.QnA_board.QnA_post.repository;
 
-import org.example.tackit.domain.entity.Member;
-import org.example.tackit.domain.entity.Post;
-import org.example.tackit.domain.entity.QnAPost;
-import org.example.tackit.domain.entity.QnAScrap;
+import org.example.tackit.domain.entity.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -16,7 +13,7 @@ import java.util.Optional;
 @Repository
 public interface QnAScrapRepository extends JpaRepository<QnAScrap, Long> {
     Optional<QnAScrap> findByUserAndQnaPost(Member user, QnAPost qnaPost);
-    void deleteByUserAndQnaPost(Member user, QnAPost qnaPost);
     @EntityGraph(attributePaths = {"qnaPost", "qnaPost.writer"}) // 페이징 함께 지원, writer까지 fetch해서 n+1방지
-    Page<QnAScrap> findByUserAndType(Member user, Post type, Pageable pageable);
+    Page<QnAScrap> findByUserAndQnaPost_Status(Member user, Status status, Pageable pageable);
+
 }

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/service/QnAPostService.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/service/QnAPostService.java
@@ -41,6 +41,7 @@ public class QnAPostService {
                 .content(dto.getContent())
                 .createdAt(LocalDateTime.now())
                 .type(Post.QnA)
+                .organization(org)
                 .status(Status.ACTIVE)
                 .reportCount(0)
                 .build();
@@ -49,14 +50,7 @@ public class QnAPostService {
 
         List<String> tagNames = tagService.assignTagsToPost(post, dto.getTagIds());
 
-        return QnAPostResponseDto.builder()
-                .postId(post.getId())
-                .writer(member.getNickname())
-                .title(post.getTitle())
-                .content(post.getContent())
-                .createdAt(post.getCreatedAt())
-                .tags(tagNames)
-                .build();
+        return QnAPostResponseDto.fromEntity(post, tagNames);
     }
 
     // 게시글 수정 (작성자만 가능)
@@ -80,14 +74,7 @@ public class QnAPostService {
         tagService.deleteTagsByPost(post); // 기존 태그 삭제
         List<String> tagNames = tagService.assignTagsToPost(post, request.getTagIds()); // 새 태그 등록
 
-        return QnAPostResponseDto.builder()
-                .postId(post.getId())
-                .writer(post.getWriter().getNickname())
-                .title(post.getTitle())
-                .content(post.getContent())
-                .createdAt(post.getCreatedAt())
-                .tags(tagNames)
-                .build();
+        return QnAPostResponseDto.fromEntity(post, tagNames);
     }
 
     // 게시글 삭제 (작성자, 관리자만 가능)
@@ -106,7 +93,7 @@ public class QnAPostService {
             throw new AccessDeniedException("작성자 또는 관리자만 삭제할 수 있습니다.");
         }
        // tagService.deleteTagsByPost(post);
-        post.markAsDeleted(); //Deleted로 soft delete
+        post.markAsDeleted(); //Deleted로 -> soft delete
     }
 
     // 게시글 전체 조회
@@ -115,14 +102,7 @@ public class QnAPostService {
 
         return PageResponseDTO.from(page, post -> {
             List<String> tagNames = tagService.getTagNamesByPost(post);
-            return QnAPostResponseDto.builder()
-                    .postId(post.getId())
-                    .writer(post.getWriter().getNickname())
-                    .title(post.getTitle())
-                    .content(post.getContent())
-                    .createdAt(post.getCreatedAt())
-                    .tags(tagNames)
-                    .build();
+            return QnAPostResponseDto.fromEntity(post, tagNames);
         });
     }
 
@@ -138,14 +118,7 @@ public class QnAPostService {
         }
         List<String> tagNames = tagService.getTagNamesByPost(post);
 
-        return QnAPostResponseDto.builder()
-                .postId(post.getId())
-                .writer(post.getWriter().getNickname())
-                .title(post.getTitle())
-                .content(post.getContent())
-                .tags(tagNames)
-                .createdAt(post.getCreatedAt())
-                .build();
+        return QnAPostResponseDto.fromEntity(post, tagNames);
     }
 
     // 게시글 신고하기

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/controller/QnATagController.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/controller/QnATagController.java
@@ -4,6 +4,10 @@ import lombok.RequiredArgsConstructor;
 import org.example.tackit.domain.QnA_board.QnA_tag.dto.response.QnATagPostResponseDto;
 import org.example.tackit.domain.QnA_board.QnA_tag.dto.response.QnATagResponseDto;
 import org.example.tackit.domain.QnA_board.QnA_tag.service.QnATagService;
+import org.example.tackit.global.dto.PageResponseDTO;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,10 +28,12 @@ public class QnATagController {
         return ResponseEntity.ok(qnATagService.getAllTags());
     }
 
-    // 특정 태그가 포함된 게시글 리스트 조회
+ /*   // 특정 태그가 포함된 게시글 리스트 조회
     @GetMapping("/{tagId}/posts")
-    public ResponseEntity<List<QnATagPostResponseDto>> getPostsByTag(@PathVariable Long tagId) {
-        List<QnATagPostResponseDto> posts = qnATagService.getPostsByTag(tagId);
-        return ResponseEntity.ok(posts);
-    }
+    public ResponseEntity<PageResponseDTO<QnATagPostResponseDto>> getPostsByTag(
+            @PathVariable Long tagId,
+            @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(qnATagService.getPostsByTag(tagId, pageable));
+    }*/
 }

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/controller/QnATagController.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/controller/QnATagController.java
@@ -28,12 +28,12 @@ public class QnATagController {
         return ResponseEntity.ok(qnATagService.getAllTags());
     }
 
- /*   // 특정 태그가 포함된 게시글 리스트 조회
+    // 특정 태그가 포함된 게시글 리스트 조회
     @GetMapping("/{tagId}/posts")
     public ResponseEntity<PageResponseDTO<QnATagPostResponseDto>> getPostsByTag(
             @PathVariable Long tagId,
             @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return ResponseEntity.ok(qnATagService.getPostsByTag(tagId, pageable));
-    }*/
+    }
 }

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/dto/response/QnATagPostResponseDto.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/dto/response/QnATagPostResponseDto.java
@@ -12,16 +12,18 @@ import java.util.List;
 
 @Data
 public class QnATagPostResponseDto{
-    private String title;
-    private String content;
-    private List<Long> tagIds;
+    private final Long postId;
+    private final String writer;
+    private final String title;
+    private final String content;
+    private final LocalDateTime createdAt;
 
-//    @QueryProjection // querydsl에서 dto 반환
-//    public QnATagPostResponseDto(Long postId, String writer, String title, String content, LocalDateTime createdAt) {
-//        this.postId = postId;
-//        this.writer = writer;
-//        this.title = title;
-//        this.content = content;
-//        this.createdAt = createdAt;
-//    }
+    @QueryProjection // querydsl에서 dto 반환
+    public QnATagPostResponseDto(Long postId, String writer, String title, String content, LocalDateTime createdAt) {
+        this.postId = postId;
+        this.writer = writer;
+        this.title = title;
+        this.content = content;
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/dto/response/QnATagPostResponseDto.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/dto/response/QnATagPostResponseDto.java
@@ -1,28 +1,27 @@
 package org.example.tackit.domain.QnA_board.QnA_tag.dto.response;
 
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
 import org.example.tackit.domain.entity.QnAPost;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-@AllArgsConstructor
-@Getter
-@Builder
-public class QnATagPostResponseDto {
-    private final String writer;
-    private final String title;
-    private final String content;
-    private final List<String> tags;
-    private final LocalDateTime createdAt;
+@Data
+public class QnATagPostResponseDto{
+    private String title;
+    private String content;
+    private List<Long> tagIds;
 
-    public QnATagPostResponseDto(QnAPost post, List<String> tags) {
-        this.writer = post.getWriter().getNickname();
-        this.title = post.getTitle();
-        this.content = post.getContent();
-        this.tags = tags;
-        this.createdAt = post.getCreatedAt();
-    }
+//    @QueryProjection // querydsl에서 dto 반환
+//    public QnATagPostResponseDto(Long postId, String writer, String title, String content, LocalDateTime createdAt) {
+//        this.postId = postId;
+//        this.writer = writer;
+//        this.title = title;
+//        this.content = content;
+//        this.createdAt = createdAt;
+//    }
 }

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/repository/QnAPostTagMapRepository.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/repository/QnAPostTagMapRepository.java
@@ -9,13 +9,12 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface QnAPostTagMapRepository extends JpaRepository<QnATagMap, Long>, QnATagCustomRepository {
+public interface QnAPostTagMapRepository extends JpaRepository<QnATagMap, Long> {
     // 게시글에 연결된 모든 태그 매핑 삭제
     void deleteAllByQnaPost(QnAPost qnaPost);
     // 게시글에 연결된 태그 매핑 조회
     List<QnATagMap> findByQnaPost(QnAPost qnaPost);
     // 특정 태그에 연결된 게시글 조회
-    List<QnATagMap> findByTag(QnATag tag);
     List<QnATagMap> findByQnaPostIn(List<QnAPost> posts);
 
 }

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/repository/QnAPostTagMapRepository.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/repository/QnAPostTagMapRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface QnAPostTagMapRepository extends JpaRepository<QnATagMap, Long> {
+public interface QnAPostTagMapRepository extends JpaRepository<QnATagMap, Long>, QnATagCustomRepository {
     // 게시글에 연결된 모든 태그 매핑 삭제
     void deleteAllByQnaPost(QnAPost qnaPost);
     // 게시글에 연결된 태그 매핑 조회

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/repository/QnATagCustomRepository.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/repository/QnATagCustomRepository.java
@@ -1,0 +1,9 @@
+package org.example.tackit.domain.QnA_board.QnA_tag.repository;
+
+import org.example.tackit.domain.QnA_board.QnA_tag.dto.response.QnATagPostResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface QnATagCustomRepository {
+    Page<QnATagPostResponseDto> findPostsByTagId(Long tagId, Pageable pageable);
+}

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/repository/QnATagCustomRepositoryImpl.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/repository/QnATagCustomRepositoryImpl.java
@@ -1,0 +1,72 @@
+//package org.example.tackit.domain.QnA_board.QnA_tag.repository;
+//
+//import com.querydsl.jpa.impl.JPAQueryFactory;
+//import org.example.tackit.domain.QnA_board.QnA_tag.dto.response.QQnATagPostResponseDto;
+//import org.example.tackit.domain.QnA_board.QnA_tag.dto.response.QnATagPostResponseDto;
+//import org.example.tackit.domain.entity.QnATagMap;
+//import org.example.tackit.domain.entity.Status;
+//import org.springframework.data.domain.Page;
+//import org.springframework.data.domain.PageImpl;
+//import org.springframework.data.domain.Pageable;
+//import org.springframework.stereotype.Repository;
+//
+//import static org.example.tackit.domain.entity.QQnAPost.qnAPost;
+//import static org.example.tackit.domain.entity.QQnATagMap.qnATagMap;
+//import static org.example.tackit.domain.entity.QQnATag.qnATag;
+//import static org.example.tackit.domain.entity.QMember.member;
+//
+//
+//
+//import java.util.List;
+//
+//@Repository
+//public class QnATagCustomRepositoryImpl implements QnATagCustomRepository{
+//
+//    private final JPAQueryFactory jpaQueryFactory;
+//
+//    // 생성자 주입: 스프링이 JPAQueryFactory를 주입해줌
+//    public QnATagCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+//        this.jpaQueryFactory = jpaQueryFactory;
+//    }
+//
+//    @Override
+//    public Page<QnATagPostResponseDto> findPostsByTagId(Long tagId, Pageable pageable){
+//        List<QnATagPostResponseDto> content = jpaQueryFactory
+//                .select(new QQnATagPostResponseDto(
+//                        qnAPost.id,
+//                        member.nickname,
+//                        qnAPost.title,
+//                        qnAPost.content,
+//                        qnAPost.createdAt
+//                ))
+//                .from(qnAPost)
+//                .join(qnAPost.writer, member).fetchJoin()
+//                .join(qnAPost., qnATagMap)
+//                .join(tagMap.tag, tag)
+//                .where(
+//                        tag.id.eq(tagId),
+//                        post.status.eq(Status.ACTIVE)
+//                )
+//                .distinct()
+//                .offset(pageable.getOffset())
+//                .limit(pageable.getPageSize())
+//                .orderBy(qnAPost.createdAt.desc())
+//                .fetch();
+//
+//        // ✅ 2. 전체 개수 조회 (총 몇 개 있는지)
+//        Long total = jpaQueryFactory
+//                .select(qnAPost.countDistinct())
+//                .from(qnAPost)
+//                .join(qnAPost.tagMaps, tagMap)
+//                .join(qnAPost.tag, tag)
+//                .where(
+//                        tag.id.eq(tagId),
+//                        post.status.eq(Status.ACTIVE)
+//                )
+//                .fetchOne();
+//
+//        return new PageImpl<>(content, pageable, total);
+//    }
+//
+//
+//}

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/repository/QnATagCustomRepositoryImpl.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/repository/QnATagCustomRepositoryImpl.java
@@ -1,72 +1,71 @@
-//package org.example.tackit.domain.QnA_board.QnA_tag.repository;
-//
-//import com.querydsl.jpa.impl.JPAQueryFactory;
-//import org.example.tackit.domain.QnA_board.QnA_tag.dto.response.QQnATagPostResponseDto;
-//import org.example.tackit.domain.QnA_board.QnA_tag.dto.response.QnATagPostResponseDto;
-//import org.example.tackit.domain.entity.QnATagMap;
-//import org.example.tackit.domain.entity.Status;
-//import org.springframework.data.domain.Page;
-//import org.springframework.data.domain.PageImpl;
-//import org.springframework.data.domain.Pageable;
-//import org.springframework.stereotype.Repository;
-//
-//import static org.example.tackit.domain.entity.QQnAPost.qnAPost;
-//import static org.example.tackit.domain.entity.QQnATagMap.qnATagMap;
-//import static org.example.tackit.domain.entity.QQnATag.qnATag;
-//import static org.example.tackit.domain.entity.QMember.member;
-//
-//
-//
-//import java.util.List;
-//
-//@Repository
-//public class QnATagCustomRepositoryImpl implements QnATagCustomRepository{
-//
-//    private final JPAQueryFactory jpaQueryFactory;
-//
-//    // 생성자 주입: 스프링이 JPAQueryFactory를 주입해줌
-//    public QnATagCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
-//        this.jpaQueryFactory = jpaQueryFactory;
-//    }
-//
-//    @Override
-//    public Page<QnATagPostResponseDto> findPostsByTagId(Long tagId, Pageable pageable){
-//        List<QnATagPostResponseDto> content = jpaQueryFactory
-//                .select(new QQnATagPostResponseDto(
-//                        qnAPost.id,
-//                        member.nickname,
-//                        qnAPost.title,
-//                        qnAPost.content,
-//                        qnAPost.createdAt
-//                ))
-//                .from(qnAPost)
-//                .join(qnAPost.writer, member).fetchJoin()
-//                .join(qnAPost., qnATagMap)
-//                .join(tagMap.tag, tag)
-//                .where(
-//                        tag.id.eq(tagId),
-//                        post.status.eq(Status.ACTIVE)
-//                )
-//                .distinct()
-//                .offset(pageable.getOffset())
-//                .limit(pageable.getPageSize())
-//                .orderBy(qnAPost.createdAt.desc())
-//                .fetch();
-//
-//        // ✅ 2. 전체 개수 조회 (총 몇 개 있는지)
-//        Long total = jpaQueryFactory
-//                .select(qnAPost.countDistinct())
-//                .from(qnAPost)
-//                .join(qnAPost.tagMaps, tagMap)
-//                .join(qnAPost.tag, tag)
-//                .where(
-//                        tag.id.eq(tagId),
-//                        post.status.eq(Status.ACTIVE)
-//                )
-//                .fetchOne();
-//
-//        return new PageImpl<>(content, pageable, total);
-//    }
-//
-//
-//}
+package org.example.tackit.domain.QnA_board.QnA_tag.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.example.tackit.domain.QnA_board.QnA_tag.dto.response.QQnATagPostResponseDto;
+import org.example.tackit.domain.QnA_board.QnA_tag.dto.response.QnATagPostResponseDto;
+import org.example.tackit.domain.entity.Status;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import static org.example.tackit.domain.entity.QQnAPost.qnAPost;
+import static org.example.tackit.domain.entity.QQnATagMap.qnATagMap;
+import static org.example.tackit.domain.entity.QQnATag.qnATag;
+import static org.example.tackit.domain.entity.QMember.member;
+
+
+
+import java.util.List;
+
+@Repository
+public class QnATagCustomRepositoryImpl implements QnATagCustomRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    // 스프링이 JPAQueryFactory를 주입
+    public QnATagCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    @Override
+    public Page<QnATagPostResponseDto> findPostsByTagId(Long tagId, Pageable pageable){
+        List<QnATagPostResponseDto> content = jpaQueryFactory
+                .select(new QQnATagPostResponseDto(
+                        qnAPost.id,
+                        member.nickname,
+                        qnAPost.title,
+                        qnAPost.content,
+                        qnAPost.createdAt
+                ))
+                .from(qnAPost)
+                .join(qnAPost.writer, member)
+                .join(qnAPost.tagMaps, qnATagMap)
+                .join(qnATagMap.tag, qnATag)
+                .where(
+                        qnATag.id.eq(tagId),
+                        qnAPost.status.eq(Status.ACTIVE)
+                )
+                .distinct()
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(qnAPost.createdAt.desc())
+                .fetch();
+
+        // 전체 개수 조회 (총 몇 개 있는지)
+        Long total = jpaQueryFactory
+                .select(qnAPost.countDistinct())
+                .from(qnAPost)
+                .join(qnAPost.tagMaps, qnATagMap)
+                .join(qnATagMap.tag, qnATag)
+                .where(
+                        qnATag.id.eq(tagId),
+                        qnAPost.status.eq(Status.ACTIVE)
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+
+}

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/repository/QnATagRepository.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/repository/QnATagRepository.java
@@ -1,14 +1,10 @@
 package org.example.tackit.domain.QnA_board.QnA_tag.repository;
 
-import org.example.tackit.domain.entity.QnAPost;
 import org.example.tackit.domain.entity.QnATag;
-import org.example.tackit.domain.entity.QnATagMap;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
-
 @Repository
-public interface QnATagRepository extends JpaRepository<QnATag, Long> {
+public interface QnATagRepository extends JpaRepository<QnATag, Long>, QnATagCustomRepository {
 }

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/service/QnATagService.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/service/QnATagService.java
@@ -11,17 +11,19 @@ import org.example.tackit.domain.entity.QnAPost;
 import org.example.tackit.domain.entity.QnATag;
 import org.example.tackit.domain.entity.QnATagMap;
 import org.example.tackit.domain.entity.Status;
+import org.example.tackit.global.dto.PageResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.function.Function;
 
 @Service
 @RequiredArgsConstructor
 public class QnATagService {
     private final QnATagRepository qnATagRepository;
-    private final QnAPostTagMapRepository qnAPostTagMapRepository;
-    private final QnAPostTagService qnAPostTagService;
 
     // 모든 태그 목록 가져오기
     public List<QnATagResponseDto> getAllTags() {
@@ -33,29 +35,11 @@ public class QnATagService {
                 .toList();
     }
 
-//    // 태그별 게시물 불러오기
-//    @Transactional(readOnly = true)
-//    public List<QnATagPostResponseDto> getPostsByTag(Long tagId) {
-//        QnATag tag = qnATagRepository.findById(tagId)
-//                .orElseThrow(() -> new IllegalArgumentException("태그가 존재하지 않습니다."));
-//
-//        List<QnAPost> posts = qnAPostTagMapRepository.findByTag(tag).stream()
-//                .map(QnATagMap::getQnaPost)
-//                .filter(post -> post.getStatus() == Status.ACTIVE) // 상태 체크
-//                .distinct() // 중복 제거
-//                .toList();
-//
-//        return posts.stream()
-//                .map(post -> {
-//                    List<String> tagNames = qnAPostTagService.getTagNamesByPost(post);
-//                    return QnATagPostResponseDto.builder()
-//                            .writer(post.getWriter().getNickname())
-//                            .title(post.getTitle())
-//                            .content(post.getContent())
-//                            .createdAt(post.getCreatedAt())
-//                            .tags(tagNames)
-//                            .build();
-//                })
-//                .toList();
-//    }
+    // 태그별 게시물 불러오기
+    @Transactional(readOnly = true)
+    public PageResponseDTO<QnATagPostResponseDto> getPostsByTag(Long tagId, Pageable pageable) {
+        Page<QnATagPostResponseDto> page = qnATagRepository.findPostsByTagId(tagId, pageable);
+        return PageResponseDTO.from(page, Function.identity()); // 이미 DTO라 변환이 필요 없음
+    }
+
 }

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/service/QnATagService.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_tag/service/QnATagService.java
@@ -33,29 +33,29 @@ public class QnATagService {
                 .toList();
     }
 
-    // 태그별 게시물 불러오기
-    @Transactional(readOnly = true)
-    public List<QnATagPostResponseDto> getPostsByTag(Long tagId) {
-        QnATag tag = qnATagRepository.findById(tagId)
-                .orElseThrow(() -> new IllegalArgumentException("태그가 존재하지 않습니다."));
-
-        List<QnAPost> posts = qnAPostTagMapRepository.findByTag(tag).stream()
-                .map(QnATagMap::getQnaPost)
-                .filter(post -> post.getStatus() == Status.ACTIVE) // 상태 체크
-                .distinct() // 중복 제거
-                .toList();
-
-        return posts.stream()
-                .map(post -> {
-                    List<String> tagNames = qnAPostTagService.getTagNamesByPost(post);
-                    return QnATagPostResponseDto.builder()
-                            .writer(post.getWriter().getNickname())
-                            .title(post.getTitle())
-                            .content(post.getContent())
-                            .createdAt(post.getCreatedAt())
-                            .tags(tagNames)
-                            .build();
-                })
-                .toList();
-    }
+//    // 태그별 게시물 불러오기
+//    @Transactional(readOnly = true)
+//    public List<QnATagPostResponseDto> getPostsByTag(Long tagId) {
+//        QnATag tag = qnATagRepository.findById(tagId)
+//                .orElseThrow(() -> new IllegalArgumentException("태그가 존재하지 않습니다."));
+//
+//        List<QnAPost> posts = qnAPostTagMapRepository.findByTag(tag).stream()
+//                .map(QnATagMap::getQnaPost)
+//                .filter(post -> post.getStatus() == Status.ACTIVE) // 상태 체크
+//                .distinct() // 중복 제거
+//                .toList();
+//
+//        return posts.stream()
+//                .map(post -> {
+//                    List<String> tagNames = qnAPostTagService.getTagNamesByPost(post);
+//                    return QnATagPostResponseDto.builder()
+//                            .writer(post.getWriter().getNickname())
+//                            .title(post.getTitle())
+//                            .content(post.getContent())
+//                            .createdAt(post.getCreatedAt())
+//                            .tags(tagNames)
+//                            .build();
+//                })
+//                .toList();
+//    }
 }

--- a/src/main/java/org/example/tackit/domain/entity/QnAPost.java
+++ b/src/main/java/org/example/tackit/domain/entity/QnAPost.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import org.example.tackit.domain.admin.model.ReportablePost;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -30,12 +32,13 @@ public class QnAPost implements ReportablePost {
     private Post type;
     private String organization;
 
-    @Column(nullable = true)
-    private String tag;
-
     @Enumerated(EnumType.STRING)
     private Status status;
     private int reportCount;
+
+    // QnATagMap 연관관계 추가
+    @OneToMany(mappedBy = "qnaPost", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<QnATagMap> tagMaps = new ArrayList<>();
 
     public void update(String title, String content){
         this.title = title;
@@ -61,6 +64,5 @@ public class QnAPost implements ReportablePost {
         this.status = Status.ACTIVE;
         this.reportCount = 0;
     }
-
 
 }


### PR DESCRIPTION
### 이슈 번호
>#58
#50

### 작업 내용
* 기존 qnaPost에 tag 필드 삭제 > QnATagMap 연관관계 추가 
    * 태그와 포스트 분리 
* post에 org 함께 저장
* 질문 스크랩 태그 응답 추가
* 스크랩 content 100자 제한
* 태그 필터링 페이징
    * queryDSL로 리팩토링

### 기타
* queryDSL 관련 gradle 추가해놨습니다
* gradle clean> build 하고 실행해주세요!~

<img width="399" alt="스크린샷 2025-05-27 오후 11 46 53" src="https://github.com/user-attachments/assets/39c43d27-bb5e-4188-a08f-eb3b5446d0aa" />
