### PR TITLE
[REFACTOR] 전체 조회, 찜한 글 태그 맵 후처리 

### DIFF
--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/service/QnAPostService.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/service/QnAPostService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -99,9 +100,12 @@ public class QnAPostService {
     // 게시글 전체 조회
     public PageResponseDTO<QnAPostResponseDto> findAll(String org, Pageable pageable) {
         Page<QnAPost> page = qnAPostRepository.findAllByStatusAndWriter_Organization(Status.ACTIVE, org, pageable);
+        List<QnAPost> posts = page.getContent();
+
+        Map<Long, List<String>> tagMap = tagService.getTagNamesByPosts(posts); 
 
         return PageResponseDTO.from(page, post -> {
-            List<String> tagNames = tagService.getTagNamesByPost(post);
+            List<String> tagNames = tagMap.getOrDefault(post.getId(), List.of());
             return QnAPostResponseDto.fromEntity(post, tagNames);
         });
     }

--- a/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/service/QnAPostTagService.java
+++ b/src/main/java/org/example/tackit/domain/QnA_board/QnA_post/service/QnAPostTagService.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -39,12 +41,24 @@ public class QnAPostTagService {
         qnAPostTagMapRepository.deleteAllByQnaPost(post);
     }
 
-    // 게시글에 연결된 태그 이름 조회
+    // 게시글에 연결된 태그 이름 조회 - 단일 포스트
+    // 단순 쿼리여도 1번이라 N+1 안생김
     public List<String> getTagNamesByPost(QnAPost post) {
         return qnAPostTagMapRepository.findByQnaPost(post).stream()
                 .map(mapping -> mapping.getTag().getTagName())
                 .toList();
     }
+
+    // 게시글에 연결된 태그 이름 조회 - 다중 포스트
+    // 게시글들 리스트로 한번에 받아서 매핑 (게시글 id - 태그 이름 리스트)
+    public Map<Long, List<String>> getTagNamesByPosts(List<QnAPost> posts) {
+        return qnAPostTagMapRepository.findByQnaPostIn(posts).stream() // 게시글 ID에 대한 태그 매핑 한번에 조회
+                .collect(Collectors.groupingBy(     //게시글 ID 기준으로 태그 이름들 그룹핑
+                        mapping -> mapping.getQnaPost().getId(),
+                        Collectors.mapping(mapping -> mapping.getTag().getTagName(), Collectors.toList())
+                ));
+    }
+
 
 
 }


### PR DESCRIPTION
### 이슈 번호
>#62

### 작업 내용
* 전체 조회, 찜한 글 태그  n+1 문제 방지
   * `QnAPostTagService`에 공통 메소드 `getTagNamesByPosts` 사용 ) 맵 후처리 
