### PR TITLE
[FIX] 입사년도 대신 역할로 전달로 수정

### DIFF
--- a/src/main/java/org/example/tackit/domain/auth/login/dto/SignUpDto.java
+++ b/src/main/java/org/example/tackit/domain/auth/login/dto/SignUpDto.java
@@ -3,6 +3,7 @@ package org.example.tackit.domain.auth.login.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.example.tackit.domain.entity.Role;
 
 @Data
 @NoArgsConstructor
@@ -12,6 +13,6 @@ public class SignUpDto {
     private String password;
     private String nickname;
     private String organization;
-    private int joinedYear;
+    private Role role;
 }
 

--- a/src/main/java/org/example/tackit/domain/auth/login/service/AuthService.java
+++ b/src/main/java/org/example/tackit/domain/auth/login/service/AuthService.java
@@ -45,18 +45,14 @@ public class AuthService {
         }
 
         int currentYear = LocalDate.now().getYear();
-        int joinedYear = signUpDto.getJoinedYear(); // 회원가입 기준으로 설정
-
-        // 가입 연도 기준으로 역할 부여
-        Role role = (joinedYear == currentYear) ? Role.NEWBIE : Role.SENIOR;
 
         Member member = Member.builder()
                 .email(signUpDto.getEmail())
                 .password(passwordEncoder.encode(signUpDto.getPassword()))
                 .nickname(signUpDto.getNickname())
                 .organization(signUpDto.getOrganization())
-                .joinedYear(signUpDto.getJoinedYear())
-                .role(role)
+                .role(signUpDto.getRole())
+                .joinedYear(currentYear)
                 .status(Status.ACTIVE)
                 .createdAt(LocalDateTime.now())
                 .build();


### PR DESCRIPTION
### 이슈 번호
> #99 

### 작업 내용
* 입사년도 (joinedYear) -> 역할 (Role)로 signupDto 변경
   * api 명세서 수정 (joinedYear -> role)  
* 기존 joinedYear 컬럼은 가입년도가 저장
